### PR TITLE
Update WORKSPACE, as per bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 workspace(name = "com_google_absl_hello_world")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # abseil
 http_archive(


### PR DESCRIPTION
Bazel deprecated BUILD.bazel:15:1: no such package '@absl//absl/strings': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.